### PR TITLE
set saveState and restoreState to false for nav bar navigation to prevent restore state failure crashing

### DIFF
--- a/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
@@ -190,10 +190,10 @@ fun InfoApp(
                         onClick = {
                             navController.navigate(navBarScreen.name) {
                                 popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
+                                    saveState = false
                                 }
                                 launchSingleTop = true
-                                restoreState = true
+                                restoreState = false
                             }
                             navBarScreen.let {
                                 preferencesViewModel.setPreference(


### PR DESCRIPTION
To reproduce the crash (might take a few tries):
go to Donate then GitHub Sponsors (or any other sub-screen I think) then go to the home screen. Come back to the app and go to the Community tab then go to the home screen again.