### PR TITLE
Save and restore state when setting new start destination

### DIFF
--- a/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
@@ -188,12 +188,19 @@ fun InfoApp(
                     NavigationBarItem(
                         selected = navBarScreen == navBarSelected,
                         onClick = {
+                            if (navBarSelected != null) {
+                                navController.popBackStack(
+                                    navBarSelected.name,
+                                    inclusive = true,
+                                    saveState = true
+                                )
+                            }
                             navController.navigate(navBarScreen.name) {
                                 popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = false
+                                    saveState = true
                                 }
                                 launchSingleTop = true
-                                restoreState = false
+                                restoreState = true
                             }
                             navBarScreen.let {
                                 preferencesViewModel.setPreference(

--- a/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
@@ -190,10 +190,10 @@ fun InfoApp(
                         onClick = {
                             navController.navigate(navBarScreen.name) {
                                 popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
+                                    saveState = false
                                 }
                                 launchSingleTop = true
-                                restoreState = true
+                                restoreState = false
                             }
                             navBarScreen.let {
                                 preferencesViewModel.setPreference(

--- a/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
@@ -130,7 +130,9 @@ fun InfoApp(
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_STOP) {
+                val state = navController.saveState()
                 startDestination = preferencesUiState.startDestination.second.value
+                navController.restoreState(state)
             }
         }
 


### PR DESCRIPTION
This prevents Donate from going back to its Start screen when it is being set as the new startDestination when leaving the app. However, it still goes back to the start screen when other nav bar entries are being set as the new startDestination.