### PR TITLE
define night-specific theme

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Info" parent="android:Theme.Material.NoActionBar"/>
+</resources>


### PR DESCRIPTION
makes text selection toolbar and splash screen background adapt to the dark theme

fixes #18 