### PR TITLE
use default TopAppBar title text style so we don't deviate from other apps

### DIFF
--- a/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
@@ -143,7 +143,6 @@ fun InfoApp() {
                 title = {
                     Text(
                         text = stringResource(id = currentScreen.title),
-                        style = typography.headlineMedium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )


### PR DESCRIPTION
# before
![image](https://github.com/user-attachments/assets/dca11c8f-e12e-4ce3-91d9-b308f633bf2f)
![image](https://github.com/user-attachments/assets/a32ec4d3-ad3b-48c2-a9ec-af68607100dc)
![image](https://github.com/user-attachments/assets/71352ed8-0fb6-4c8f-a51b-ce573dd5e90d)

# after
![image](https://github.com/user-attachments/assets/0d27a91d-6014-47b2-a3db-f4cd899c6292)
![image](https://github.com/user-attachments/assets/927fce3f-4efa-47ed-b6b2-0d59cedf3e1c)
![image](https://github.com/user-attachments/assets/f10fcc01-bc88-4c55-9d1b-3a0542f6194d)
