### PR TITLE
rename release notes screen to releases and rename some releases screen related code for separation, clarity, and naming consistency with website

### DIFF
--- a/app/src/main/kotlin/app/grapheneos/info/Application.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/Application.kt
@@ -2,9 +2,10 @@ package app.grapheneos.info
 
 import android.net.http.HttpResponseCache
 import android.util.Log
-import app.grapheneos.info.ui.releases.TAG
 import java.io.File
 import java.io.IOException
+
+const val TAG = "Application"
 
 class Application : android.app.Application() {
     override fun onCreate() {

--- a/app/src/main/kotlin/app/grapheneos/info/Application.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/Application.kt
@@ -2,7 +2,7 @@ package app.grapheneos.info
 
 import android.net.http.HttpResponseCache
 import android.util.Log
-import app.grapheneos.info.ui.releasenotes.TAG
+import app.grapheneos.info.ui.releases.TAG
 import java.io.File
 import java.io.IOException
 

--- a/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
@@ -136,9 +136,9 @@ fun InfoApp() {
 
     val releasesUiState = releasesViewModel.uiState.collectAsState()
 
-    val releaseNotesLazyListState = rememberLazyListState()
+    val changelogLazyListState = rememberLazyListState()
 
-    val releaseNotesLazyListStateScope = rememberCoroutineScope()
+    val changelogLazyListStateScope = rememberCoroutineScope()
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -286,23 +286,23 @@ fun InfoApp() {
                             .consumeWindowInsets(innerPadding),
                         entries =
                             releasesUiState.value.entries.toSortedMap().toList().asReversed(),
-                        updateReleaseNotes = { useCaches, onFinishedUpdating ->
-                            releasesViewModel.updateReleaseNotes(
+                        updateChangelog = { useCaches, onFinishedUpdating ->
+                            releasesViewModel.updateChangelog(
                                 useCaches = useCaches,
                                 showSnackbarError = {
                                     snackbarHostState.showSnackbar(it)
                                 },
                                 {
-                                    releaseNotesLazyListStateScope.launch {
+                                    changelogLazyListStateScope.launch {
                                         withContext(Dispatchers.Main) {
-                                            releaseNotesLazyListState.animateScrollToItem(it)
+                                            changelogLazyListState.animateScrollToItem(it)
                                         }
                                     }
                                 },
                                 onFinishedUpdating = onFinishedUpdating,
                             )
                         },
-                        lazyListState = releaseNotesLazyListState,
+                        changelogLazyListState = changelogLazyListState,
                         additionalContentPadding = PaddingValues(
                             start = innerPadding.calculateStartPadding(layoutDirection),
                             top = 0.dp,

--- a/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
@@ -77,14 +77,14 @@ import app.grapheneos.info.ui.donate.cryptocurrency.EthereumScreen
 import app.grapheneos.info.ui.donate.cryptocurrency.LitecoinScreen
 import app.grapheneos.info.ui.donate.cryptocurrency.MoneroScreen
 import app.grapheneos.info.ui.donate.cryptocurrency.ZcashScreen
-import app.grapheneos.info.ui.releasenotes.ReleaseNotesScreen
-import app.grapheneos.info.ui.releasenotes.ReleaseNotesViewModel
+import app.grapheneos.info.ui.releases.ReleasesScreen
+import app.grapheneos.info.ui.releases.ReleasesViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 enum class InfoAppScreens(@StringRes val title: Int) {
-    ReleaseNotes(title = R.string.release_notes),
+    Releases(title = R.string.releases),
     Community(title = R.string.community),
     Donate(title = R.string.donate),
     DonateStart(title = R.string.donate),
@@ -102,7 +102,7 @@ enum class InfoAppScreens(@StringRes val title: Int) {
 }
 
 val navSuiteItemScreens = arrayOf(
-    InfoAppScreens.ReleaseNotes,
+    InfoAppScreens.Releases,
     InfoAppScreens.Community,
     InfoAppScreens.Donate
 )
@@ -132,9 +132,9 @@ fun InfoApp() {
         currentScreen.name.startsWith(it.name)
     }
 
-    val releaseNotesViewModel: ReleaseNotesViewModel = viewModel()
+    val releasesViewModel: ReleasesViewModel = viewModel()
 
-    val releaseNotesUiState = releaseNotesViewModel.uiState.collectAsState()
+    val releasesUiState = releasesViewModel.uiState.collectAsState()
 
     val releaseNotesLazyListState = rememberLazyListState()
 
@@ -189,7 +189,7 @@ fun InfoApp() {
                     },
                     icon = {
                         when (navSuiteItemScreen) {
-                            InfoAppScreens.ReleaseNotes -> Icon(
+                            InfoAppScreens.Releases -> Icon(
                                 painter = painterResource(id = R.drawable.outline_newsmode),
                                 contentDescription = null
                             )
@@ -244,7 +244,7 @@ fun InfoApp() {
                         }
                     },
                     actions = {
-                        if (navSuiteItemScreenSelected == InfoAppScreens.ReleaseNotes) {
+                        if (navSuiteItemScreenSelected == InfoAppScreens.Releases) {
                             IconButton(
                                 onClick = {
                                     try {
@@ -260,7 +260,7 @@ fun InfoApp() {
                             ) {
                                 Icon(
                                     imageVector = Icons.Outlined.Info,
-                                    contentDescription = stringResource(R.string.release_notes_top_bar_info_button_content_description)
+                                    contentDescription = stringResource(R.string.releases_top_bar_info_button_content_description)
                                 )
                             }
                         }
@@ -277,17 +277,17 @@ fun InfoApp() {
                 startDestination = startDestination,
             ) {
                 composableWithDefaultSlideTransitions(
-                    route = InfoAppScreens.ReleaseNotes,
+                    route = InfoAppScreens.Releases,
                     navigationSuiteType = navigationSuiteType,
                 ) {
-                    ReleaseNotesScreen(
+                    ReleasesScreen(
                         modifier = Modifier
                             .padding(top = innerPadding.calculateTopPadding())
                             .consumeWindowInsets(innerPadding),
                         entries =
-                            releaseNotesUiState.value.entries.toSortedMap().toList().asReversed(),
+                            releasesUiState.value.entries.toSortedMap().toList().asReversed(),
                         updateReleaseNotes = { useCaches, onFinishedUpdating ->
-                            releaseNotesViewModel.updateReleaseNotes(
+                            releasesViewModel.updateReleaseNotes(
                                 useCaches = useCaches,
                                 showSnackbarError = {
                                     snackbarHostState.showSnackbar(it)

--- a/app/src/main/kotlin/app/grapheneos/info/preferences/PreferencesViewModel.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/preferences/PreferencesViewModel.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import app.grapheneos.info.InfoAppScreens
 import app.grapheneos.info.dataStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -39,7 +40,16 @@ class PreferencesViewModel(private val application: Application) : AndroidViewMo
                 _uiState.update {
                     PreferencesUiState(
                         isPreferencesLoaded = mutableStateOf(true),
-                        startDestination = getPreferencePair(uiState.value.startDestination)
+                        startDestination = getPreferencePair(uiState.value.startDestination).let {
+                            // migrate from old value
+                            if (it.second.value == "ReleaseNotes") {
+                                it.copy(
+                                    second = mutableStateOf(InfoAppScreens.Releases.name)
+                                )
+                            } else {
+                                it
+                            }
+                        }
                     )
                 }
             }.collect()

--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/Changelog.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/Changelog.kt
@@ -1,4 +1,4 @@
-package app.grapheneos.info.ui.releasenotes
+package app.grapheneos.info.ui.releases
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -16,7 +16,6 @@ import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesScreen.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesScreen.kt
@@ -1,4 +1,4 @@
-package app.grapheneos.info.ui.releasenotes
+package app.grapheneos.info.ui.releases
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
@@ -33,7 +33,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ReleaseNotesScreen(
+fun ReleasesScreen(
     modifier: Modifier = Modifier,
     entries: List<Pair<String, String>>,
     updateReleaseNotes: (useCaches: Boolean, finishedUpdating: () -> Unit) -> Unit,
@@ -106,7 +106,7 @@ fun ReleaseNotesScreen(
                     horizontalArrangement = Arrangement.Center,
                 ) {
                     Button(onClick = { localUriHandler.openUri("https://grapheneos.org/releases") }) {
-                        Text(text = stringResource(R.string.release_notes_see_all_button))
+                        Text(text = stringResource(R.string.releases_see_all_button))
                     }
                 }
             }

--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesScreen.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesScreen.kt
@@ -36,8 +36,8 @@ import kotlinx.coroutines.launch
 fun ReleasesScreen(
     modifier: Modifier = Modifier,
     entries: List<Pair<String, String>>,
-    updateReleaseNotes: (useCaches: Boolean, finishedUpdating: () -> Unit) -> Unit,
-    lazyListState: LazyListState,
+    updateChangelog: (useCaches: Boolean, finishedUpdating: () -> Unit) -> Unit,
+    changelogLazyListState: LazyListState,
     additionalContentPadding: PaddingValues = PaddingValues(0.dp)
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -50,7 +50,7 @@ fun ReleasesScreen(
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_START) {
                 refreshCoroutineScope.launch {
-                    updateReleaseNotes(true) {}
+                    updateChangelog(true) {}
                 }
             }
         }
@@ -70,7 +70,7 @@ fun ReleasesScreen(
         isRefreshing = isRefreshing,
         onRefresh = {
             isRefreshing = true
-            updateReleaseNotes(false) {
+            updateChangelog(false) {
                 isRefreshing = false
 
                 refreshCoroutineScope.launch {
@@ -85,7 +85,7 @@ fun ReleasesScreen(
         ScreenLazyColumn(
             modifier = Modifier
                 .fillMaxSize(),
-            state = lazyListState,
+            state = changelogLazyListState,
             additionalContentPadding = additionalContentPadding,
             verticalArrangement = Arrangement.Top
         ) {

--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesUiState.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesUiState.kt
@@ -1,4 +1,4 @@
-package app.grapheneos.info.ui.releasenotes
+package app.grapheneos.info.ui.releases
 
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
 import androidx.lifecycle.viewmodel.compose.saveable
 
 @OptIn(SavedStateHandleSaveableApi::class)
-class ReleaseNotesUiState(savedStateHandle: SavedStateHandle) {
+class ReleasesUiState(savedStateHandle: SavedStateHandle) {
     var didInitialScroll: Boolean by savedStateHandle.saveable {
         mutableStateOf(false)
     }

--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesViewModel.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesViewModel.kt
@@ -31,19 +31,19 @@ class ReleasesViewModel(
     val uiState: StateFlow<ReleasesUiState> = _uiState.asStateFlow()
 
     init {
-        updateReleaseNotes(
+        updateChangelog(
             useCaches = true,
             showSnackbarError = {},
-            scrollReleaseNotesLazyListTo = {},
+            scrollChangelogLazyListTo = {},
             countAsInitialScroll = false,
             onFinishedUpdating = {},
         )
     }
 
-    fun updateReleaseNotes(
+    fun updateChangelog(
         useCaches: Boolean,
         showSnackbarError: suspend (message: String) -> Unit,
-        scrollReleaseNotesLazyListTo: (scrollTo: Int) -> Unit,
+        scrollChangelogLazyListTo: (scrollTo: Int) -> Unit,
         countAsInitialScroll: Boolean = true,
         onFinishedUpdating: () -> Unit = {},
     ) {
@@ -98,25 +98,25 @@ class ReleasesViewModel(
 
                     if (countAsInitialScroll && !uiState.value.didInitialScroll) {
                         _uiState.value.didInitialScroll = true
-                        scrollReleaseNotesLazyListTo(currentOsChangelogIndex)
+                        scrollChangelogLazyListTo(currentOsChangelogIndex)
                     }
                 } catch (e: SocketTimeoutException) {
                     val errorMessage =
-                        application.getString(R.string.update_release_notes_socket_timeout_exception_snackbar_message)
+                        application.getString(R.string.update_changelog_socket_timeout_exception_snackbar_message)
                     Log.e(TAG, errorMessage, e)
                     viewModelScope.launch {
                         showSnackbarError("$errorMessage: $e")
                     }
                 } catch (e: IOException) {
                     val errorMessage =
-                        application.getString(R.string.update_release_notes_io_exception_snackbar_message)
+                        application.getString(R.string.update_changelog_io_exception_snackbar_message)
                     Log.e(TAG, errorMessage, e)
                     viewModelScope.launch {
                         showSnackbarError("$errorMessage: $e")
                     }
                 } catch (e: UnknownServiceException) {
                     val errorMessage =
-                        application.getString(R.string.update_release_notes_unknown_service_exception_snackbar_message)
+                        application.getString(R.string.update_changelog_unknown_service_exception_snackbar_message)
                     Log.e(TAG, errorMessage, e)
                     viewModelScope.launch {
                         showSnackbarError("$errorMessage: $e")
@@ -126,7 +126,7 @@ class ReleasesViewModel(
                 }
             } catch (e: IOException) {
                 val errorMessage =
-                    application.getString(R.string.update_release_notes_failed_to_create_httpsurlconnection_snackbar_message)
+                    application.getString(R.string.update_changelog_failed_to_create_httpsurlconnection_snackbar_message)
                 Log.e(TAG, errorMessage, e)
                 viewModelScope.launch {
                     showSnackbarError("$errorMessage: $e")

--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesViewModel.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/ReleasesViewModel.kt
@@ -1,4 +1,4 @@
-package app.grapheneos.info.ui.releasenotes
+package app.grapheneos.info.ui.releases
 
 import android.app.Application
 import android.util.Log
@@ -12,23 +12,23 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.grapheneos.tls.ModernTLSSocketFactory
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.URL
 import java.net.UnknownServiceException
 import javax.net.ssl.HttpsURLConnection
-import org.grapheneos.tls.ModernTLSSocketFactory
 
-const val TAG = "ReleaseNotesViewModel"
+const val TAG = "ReleasesViewModel"
 
-class ReleaseNotesViewModel(
+class ReleasesViewModel(
     private val application: Application,
     savedStateHandle: SavedStateHandle
 ) : AndroidViewModel(application) {
 
     private val tlsSocketFactory = ModernTLSSocketFactory()
-    private val _uiState = MutableStateFlow(ReleaseNotesUiState(savedStateHandle))
-    val uiState: StateFlow<ReleaseNotesUiState> = _uiState.asStateFlow()
+    private val _uiState = MutableStateFlow(ReleasesUiState(savedStateHandle))
+    val uiState: StateFlow<ReleasesUiState> = _uiState.asStateFlow()
 
     init {
         updateReleaseNotes(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Info</string>
-    <string name="release_notes">Release Notes</string>
+    <string name="releases">Releases</string>
     <string name="community">Community</string>
     <string name="donate">Donate</string>
     <string name="github_sponsors">GitHub Sponsors</string>
@@ -137,6 +137,6 @@
     <string name="screen_nav_card_item_on_click_label">open screen</string>
     <string name="account_info_item_copy_term">Copy %1$s</string>
     <string name="browser_link_illegal_argument_exception_snackbar_error">Unable to open link. Make sure a browser is installed and enabled on your device.</string>
-    <string name="release_notes_top_bar_info_button_content_description">Info about the releases</string>
-    <string name="release_notes_see_all_button">See all release notes</string>
+    <string name="releases_top_bar_info_button_content_description">Info about the releases</string>
+    <string name="releases_see_all_button">See all release notes</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,10 +128,10 @@
     <string name="monero_qr_code_description">Monero donation QR code</string>
     <string name="zcash_info">Zcash can be used to make donations to the non-profit GrapheneOS Foundation.</string>
     <string name="zcash_transparent_qr_code_description">Transparent Zcash donation QR code</string>
-    <string name="update_release_notes_socket_timeout_exception_snackbar_message">Socket Timeout Exception</string>
-    <string name="update_release_notes_io_exception_snackbar_message">Failed to retrieve latest release notes</string>
-    <string name="update_release_notes_unknown_service_exception_snackbar_message">Unknown Service Exception</string>
-    <string name="update_release_notes_failed_to_create_httpsurlconnection_snackbar_message">Failed to create
+    <string name="update_changelog_socket_timeout_exception_snackbar_message">Socket Timeout Exception</string>
+    <string name="update_changelog_io_exception_snackbar_message">Failed to retrieve latest release notes</string>
+    <string name="update_changelog_unknown_service_exception_snackbar_message">Unknown Service Exception</string>
+    <string name="update_changelog_failed_to_create_httpsurlconnection_snackbar_message">Failed to create
         HttpsURLConnection
     </string>
     <string name="screen_nav_card_item_on_click_label">open screen</string>


### PR DESCRIPTION
"Release Notes" is too long for the navigation bar. "Releases" works well and is the same as the website. It also makes sense to separate the releases screen from the actual release notes in naming.

Migration code added and tested for start destination preferences which were set to "ReleaseNotes".

Rename remaining mentions of release notes in code to changelog for separation, clarity, and naming consistency with website.

resolves #67 