### PR TITLE
support some relative URLs in changelogs

### DIFF
--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/Changelog.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/Changelog.kt
@@ -73,9 +73,18 @@ private fun NodeToComposable(
 
         when (attribute.nodeName) {
             "href" -> {
+                val hrefValue = attribute.nodeValue
+                val home = "https://grapheneos.org"
+                val url = if (hrefValue.startsWith('/')) {
+                    "$home$hrefValue"
+                } else if (hrefValue.startsWith('#')) {
+                    "$home/releases$hrefValue"
+                } else {
+                    hrefValue
+                }
                 builder.apply {
-                    pushLink(LinkAnnotation.Url(attribute.nodeValue))
-                    pushStringAnnotation("URL", attribute.nodeValue)
+                    pushLink(LinkAnnotation.Url(url))
+                    pushStringAnnotation("URL", url)
                     pushStyle(SpanStyle(color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold))
                 }
             }


### PR DESCRIPTION
Previously, stuff such as linking to releases just wouldn't work when clicking on them because they were relative URLs.