### PR TITLE
Add wise quick link

### DIFF
--- a/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/InfoApp.kt
@@ -507,7 +507,12 @@ fun InfoApp() {
                     ) {
                         BankTransfersScreen(
                             modifier = Modifier.consumeWindowInsets(innerPadding),
-                            additionalContentPadding = innerPadding
+                            additionalContentPadding = innerPadding,
+                            showSnackbarError = {
+                                snackbarCoroutine.launch {
+                                    snackbarHostState.showSnackbar(it)
+                                }
+                            }
                         )
                     }
                 }

--- a/app/src/main/kotlin/app/grapheneos/info/ui/donate/banktransfers/BankTransfersScreen.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/donate/banktransfers/BankTransfersScreen.kt
@@ -21,7 +21,8 @@ import app.grapheneos.info.ui.reusablecomposables.ScreenLazyColumn
 @Composable
 fun BankTransfersScreen(
     modifier: Modifier = Modifier,
-    additionalContentPadding: PaddingValues = PaddingValues(0.dp)
+    additionalContentPadding: PaddingValues = PaddingValues(0.dp),
+    showSnackbarError: (String) -> Unit = {}
 ) {
     ScreenLazyColumn(
         modifier = modifier
@@ -33,6 +34,11 @@ fun BankTransfersScreen(
                 stringResource(R.string.local_bank_transfer_to_wise),
                 modifier = Modifier.padding(top = 16.dp),
                 style = MaterialTheme.typography.titleLarge
+            )
+        }
+        item {
+            WiseQuickLinkCard(
+                showSnackbarError = showSnackbarError
             )
         }
         item {

--- a/app/src/main/kotlin/app/grapheneos/info/ui/donate/banktransfers/WiseQuickLinkCard.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/donate/banktransfers/WiseQuickLinkCard.kt
@@ -1,0 +1,65 @@
+package app.grapheneos.info.ui.donate.banktransfers
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Wallpapers
+import androidx.compose.ui.unit.dp
+import app.grapheneos.info.R
+
+@Composable
+fun WiseQuickLinkCard(
+    modifier: Modifier = Modifier,
+    showSnackbarError: (String) -> Unit = {}
+) {
+    val wiseQuickLinkUrl = "https://wise.com/pay/business/grapheneosfoundation"
+    val uriHandler = LocalUriHandler.current
+    val openUriIllegalArgumentExceptionSnackbarError =
+        stringResource(R.string.browser_link_illegal_argument_exception_snackbar_error)
+
+    ElevatedCard(
+        onClick = {
+            try {
+                uriHandler.openUri(wiseQuickLinkUrl)
+            } catch (_: IllegalArgumentException) {
+                showSnackbarError(openUriIllegalArgumentExceptionSnackbarError)
+            }
+        },
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.wise_quick_link_title),
+                Modifier.padding(bottom = 24.dp),
+                style = MaterialTheme.typography.titleLarge
+            )
+            Text(
+                text = stringResource(R.string.wise_quick_link_description)
+            )
+        }
+    }
+}
+
+
+@Preview(
+    showBackground = true,
+    wallpaper = Wallpapers.RED_DOMINATED_EXAMPLE,
+    uiMode = Configuration.UI_MODE_NIGHT_UNDEFINED
+)
+@Composable
+fun WiseQuickLinkCardPreview() {
+    MaterialTheme {
+        WiseQuickLinkCard()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,11 @@
     <string name="cardano">Cardano</string>
     <string name="litecoin">Litecoin</string>
     <string name="local_bank_transfer_to_wise">Local Bank Transfer to Wise</string>
+    <string name="wise_quick_link_title">Wise Quick Pay</string>
+    <string name="wise_quick_link_description">If you have a Wise account, you can donate directly via Wise using our Wise Quick Pay link rather than using the bank account details.
+        This enables sending donations from anywhere Wise is available. If the currency you\'re using isn\'t listed due to not being one of the currencies where we accept local bank transfers,
+        please select CAD or USD so we can avoid another conversion.
+    </string>
     <string name="eu_sepa_eur">EU/SEPA (EUR)</string>
     <string name="account_holder">Account holder</string>
     <string name="grapheneos_foundation">GrapheneOS Foundation</string>


### PR DESCRIPTION
This adds the [Wise Quick Link](https://grapheneos.org/donate#wise) to the local bank transfer screen. The entire card is clickable and will navigate the user to the link. 

<img width="1080" height="2340" alt="Screenshot_20251004-134829_Info" src="https://github.com/user-attachments/assets/486900b1-06ab-47be-9a97-5b5fc66ee665" />

Thanks!
