### PR TITLE
Fix: handle offline mode gracefully on Releases screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,4 +139,8 @@
     <string name="browser_link_illegal_argument_exception_snackbar_error">Unable to open link. Make sure a browser is installed and enabled on your device.</string>
     <string name="releases_top_bar_info_button_content_description">Info about the releases</string>
     <string name="releases_see_all_button">See all release notes</string>
+    <string name="update_changelog_no_internet_connection_snackbar_message">
+    Internet connection not found
+    </string>
+
 </resources>


### PR DESCRIPTION
Related Issue:
Fixes: https://github.com/GrapheneOS/Info/issues/78

This PR improves offline handling on the Releases screen.
A custom network check was added and a user-friendly
"Internet connection not found" snackbar message is shown
instead of an exception crash.
