### PR TITLE
Show build dates under release build numbers

### DIFF
--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/Changelog.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/Changelog.kt
@@ -180,7 +180,7 @@ private fun ParseChildren(
                             )
                             buildDate?.let {
                                 Text(
-                                    text = it.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)),
+                                    text = it.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)) + " (UTC)",
                                     style = typography.titleSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )

--- a/app/src/main/kotlin/app/grapheneos/info/ui/releases/Changelog.kt
+++ b/app/src/main/kotlin/app/grapheneos/info/ui/releases/Changelog.kt
@@ -29,6 +29,11 @@ import org.w3c.dom.Document
 import org.w3c.dom.Node
 import org.xml.sax.InputSource
 import java.io.StringReader
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.format.FormatStyle
+import java.util.Locale
 import javax.xml.parsers.DocumentBuilderFactory
 
 @Composable
@@ -151,18 +156,36 @@ private fun ParseChildren(
 
                         val annotatedString = annotatedStringBuilder.toAnnotatedString()
 
-                        ClickableText(
-                            text = annotatedString,
-                            modifier = modifier.semantics { heading() },
-                            onClick = { offset ->
-                                annotatedString
-                                    .getStringAnnotations("URL", offset, offset).firstOrNull()
-                                    ?.let { annotation ->
-                                        localUriHandler.openUri(annotation.item)
-                                    }
-                            },
-                            style = typography.titleLarge,
-                        )
+                        val buildDate = try {
+                            LocalDate.parse(
+                                annotatedString.text.take(8),
+                                DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ROOT)
+                            )
+                        } catch (_: DateTimeParseException) {
+                            null
+                        }
+
+                        Column {
+                            ClickableText(
+                                text = annotatedString,
+                                modifier = modifier.semantics { heading() },
+                                onClick = { offset ->
+                                    annotatedString
+                                        .getStringAnnotations("URL", offset, offset).firstOrNull()
+                                        ?.let { annotation ->
+                                            localUriHandler.openUri(annotation.item)
+                                        }
+                                },
+                                style = typography.titleLarge,
+                            )
+                            buildDate?.let {
+                                Text(
+                                    text = it.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)),
+                                    style = typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
                     }
 
                     "content" -> NodeToComposable(


### PR DESCRIPTION
Build numbers include the date in YYYYMMDD## format, but only the raw number was shown. Now the date appears below each build number, formatted for the user's locale.

The build number itself stays unchanged. The date is rendered as separate text so it doesn't inherit the title style.

Closes #4