### PR TITLE
update target SDK to 37

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
     defaultConfig {
         applicationId = "app.grapheneos.info"
         minSdk = 33
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 7
         versionName = versionCode.toString()
 


### PR DESCRIPTION
Updates targetSDK to 37. 

Tested screens:

- Releases
- Community
- Donate
- DonateGithubSponsors
- DonateCryptocurrencies
- DonateCryptocurrenciesBitcoin
- DonateCryptocurrenciesMonero
- DonateCryptocurrenciesZcash
- DonateCryptocurrenciesEthereum
- DonateCryptocurrenciesCardano
- `DonateCryptocurrenciesLitecoin`
- DonatePaypal
- DonateBankTransfers

There does not appear to be any automated tests in this repository to run.

The `android:enableOnBackInvokedCallback` property is opt-out as of SDK 36 and may be removed at another time.